### PR TITLE
Update taskipy dependency to version 1.14.1 and specify Python version in installation script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -68,7 +68,7 @@ function configurar_git() {
 }
 
 function instalar_dependencias_python() {
-  poetry add --group dev ruff pytest pytest-cov pytest-blue taskipy
+  poetry add --group dev ruff pytest pytest-cov pytest-blue "taskipy@^1.14.1" --python ">=3.6,<4.0"
   poetry add --group doc mkdocs mkdocs-material mkdocstrings mkdocstrings-python
 
   if [[ "$isgit" == "y" ]]; then


### PR DESCRIPTION
Update the taskipy dependency to ensure compatibility and specify the Python version range for installation.